### PR TITLE
getComponentPaths should only iterate over directories

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -45,7 +45,6 @@ const getServingUrl = async (dir) => {
 };
 
 const getComponentPaths = async (dir) => {
-  fs.readdir(`${path.resolve("./")}/${dir}`, { withFileTypes: true }, (error, files) => {
-    return files.filter((item) => item.isDirectory())
-  });
+  const items = await fs.readdir(`${path.resolve("./")}/${dir}`, { withFileTypes: true });
+  return items.filter((item) => item.isDirectory()).map(item => item.name);
 };

--- a/src/generator.js
+++ b/src/generator.js
@@ -45,5 +45,7 @@ const getServingUrl = async (dir) => {
 };
 
 const getComponentPaths = async (dir) => {
-  return fs.readdir(`${path.resolve("./")}/${dir}`);
+  fs.readdir(`${path.resolve("./")}/${dir}`, { withFileTypes: true }, (error, files) => {
+    return files.filter((item) => item.isDirectory())
+  });
 };


### PR DESCRIPTION
I have the issue that when running build for the second time (or third and so on) new images get created on the basis of not only the folders but also the files (is already generated images) in the output folder.

This should fix it, but I have not yet tested it.

This is the error I get:

```
 ERROR  UNKNOWN

Error: ENOTDIR: not a directory, stat '/home/receter/projects/userbrain-wrapped-2022/public/__og-image/a818fc0c-9da0-5548-bbb8-ce99e79d9f13.png/index.html'

🖼 Created image at public/__og-image/a818fc0c-9da0-5548-bbb8-ce99e79d9f13.png.png
🖼 Created image at public/__og-image/ed8ae7e2-163e-5edb-bee1-cfe3b1ab812c.png
```